### PR TITLE
Supports new ID Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+tags


### PR DESCRIPTION
#### Changes

- Skips encode verification
- Treats `appid` like `aud`
- Try to make `email` exists on the result payload